### PR TITLE
include part of root webpack.conf.js

### DIFF
--- a/utils/webserver.js
+++ b/utils/webserver.js
@@ -25,7 +25,7 @@ delete config.chromeExtensionBoilerplate;
 var compiler = webpack(config);
 
 var server =
-  new WebpackDevServer(compiler, {
+  new WebpackDevServer(compiler, conf.devServer, {
     hot: true,
     contentBase: path.join(__dirname, "../build"),
     headers: { "Access-Control-Allow-Origin": "*" }


### PR DESCRIPTION
So we could modify WebpackDevServer options from main webpack config
```
devServer: {
  stats: {
    colors: true
  }
}
```
for example to colorize output