### PR TITLE
closes #19 - no console output during yarn build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "A boilerplate to chrome extension with webpack",
   "scripts": {
-    "build": "node utils/build.js",
+    "build": "webpack",
     "start": "node utils/webserver.js"
   },
   "devDependencies": {


### PR DESCRIPTION
`utils/build.js` is adding nothing to build process, but causes loss of console output

replacing the build script with simple call to `webpack` will fix it