### PR TITLE
Remove eval from production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A boilerplate to chrome extension with webpack",
   "scripts": {
     "build": "node utils/build.js",
+    "build-prod": "NODE_ENV=production node utils/build.js",
     "start": "node utils/webserver.js"
   },
   "dependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,9 @@ var options = {
     path: path.join(__dirname, "build"),
     filename: "[name].bundle.js"
   },
+  optimization: {
+		minimize: false // <---- disables uglify.
+	},
   module: {
     rules: [
       {
@@ -66,11 +69,15 @@ var options = {
       from: "src/manifest.json",
       transform: function (content, path) {
         // generates the manifest file using the package.json informations
-        return Buffer.from(JSON.stringify({
+        var manifest = {
           description: process.env.npm_package_description,
           version: process.env.npm_package_version,
           ...JSON.parse(content.toString())
-        }))
+        };
+        if (env.NODE_ENV === 'production') {
+          delete manifest.content_security_policy;
+        }
+        return Buffer.from(JSON.stringify(manifest));
       }
     }]),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
Also disables webpack uglify to meet Google's "Code readability requirements"