### PR TITLE
add zip script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A boilerplate to chrome extension with webpack",
   "scripts": {
     "build": "node utils/build.js",
-    "start": "node utils/webserver.js"
+    "start": "node utils/webserver.js",
+    "zip": "node utils/zip.js"
   },
   "devDependencies": {
     "clean-webpack-plugin": "3.0.0",
@@ -16,8 +17,9 @@
     "html-webpack-plugin": "3.2.0",
     "style-loader": "1.0.0",
     "webpack": "4.41.2",
+    "webpack-cli": "3.3.10",
     "webpack-dev-server": "3.9.0",
     "write-file-webpack-plugin": "4.5.1",
-    "webpack-cli": "3.3.10"
+    "zip-webpack-plugin": "^3.0.0"
   }
 }

--- a/utils/zip.js
+++ b/utils/zip.js
@@ -1,0 +1,16 @@
+var webpack = require("webpack"),
+    ZipPlugin = require("zip-webpack-plugin"),
+    config = require("../webpack.config");
+
+delete config.chromeExtensionBoilerplate;
+
+config.plugins = (config.plugins || []).concat(new ZipPlugin({
+  path: '..', // don't save the zip file inside the build directory
+  filename: 'dist', // file will be dist.zip
+  extension: 'zip'
+}))
+
+webpack(
+  config,
+  function (err) { if (err) throw err; }
+);


### PR DESCRIPTION
To publish the extension on Google you need to zip it first. This script, that can be run with `npm run zip`  will build the extension and zip its content into a file called `dist.zip` at the root of the project.