### PR TITLE
fix: always copy manifest file

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,7 +66,9 @@ var options = {
           ...JSON.parse(content.toString())
         }))
       }
-    }]),
+    }],
+      { copyUnmodified: true }
+    ),
     new HtmlWebpackPlugin({
       template: path.join(__dirname, "src", "popup.html"),
       filename: "popup.html",


### PR DESCRIPTION
Current behaviour:
1. run webpack as watch mode
2. modify some file
3. reload chrome extension
4. get an error caused by lack of manifest in the build directory

The [`copyUnmodified` option](https://github.com/webpack-contrib/copy-webpack-plugin#copyunmodified) fixes this problem

Out of scope: JS Style format