### PR TITLE
Add hot-reload of the extension in Chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "A boilerplate to chrome extension with webpack",
   "scripts": {
-    "build": "node utils/build.js",
+    "build": "NODE_ENV=production node utils/build.js",
     "start": "node utils/webserver.js"
   },
   "devDependencies": {

--- a/src/js/hot-reload.js
+++ b/src/js/hot-reload.js
@@ -1,0 +1,52 @@
+const filesInDirectory = dir => new Promise (resolve =>
+
+    dir.createReader ().readEntries (entries =>
+
+        Promise.all (entries.filter (e => e.name[0] !== '.').map (e =>
+
+            e.isDirectory
+                ? filesInDirectory (e)
+                : new Promise (resolve => e.file (resolve))
+        ))
+        .then (files => [].concat (...files))
+        .then (resolve)
+    )
+)
+
+const timestampForFilesInDirectory = dir =>
+        filesInDirectory (dir).then (files =>
+            files.map (f => f.name + f.lastModified).join ())
+
+const reload = () => {
+
+    chrome.tabs.query ({ active: true, currentWindow: true }, tabs => { // NB: see https://github.com/xpl/crx-hotreload/issues/5
+
+        if (tabs[0]) { chrome.tabs.reload (tabs[0].id) }
+
+        chrome.runtime.reload ()
+    })
+}
+
+const watchChanges = (dir, lastTimestamp) => {
+
+    timestampForFilesInDirectory (dir).then (timestamp => {
+
+        if (!lastTimestamp || (lastTimestamp === timestamp)) {
+
+            setTimeout (() => watchChanges (dir, timestamp), 1000) // retry after 1s
+
+        } else {
+
+            reload ()
+        }
+    })
+
+}
+
+chrome.management.getSelf (self => {
+
+    if (self.installType === 'development') {
+
+        chrome.runtime.getPackageDirectoryEntry (dir => watchChanges (dir))
+    }
+})

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,10 @@
   "name": "Chrome Extension Webpack",
   "options_page": "options.html",
   "background": {
-    "page": "background.html"
+    "scripts": [
+      "background.bundle.js",
+      "hot_reload.bundle.js"
+    ]
   },
   "browser_action": {
     "default_popup": "popup.html",

--- a/utils/webserver.js
+++ b/utils/webserver.js
@@ -32,7 +32,8 @@ var server =
     headers: {
       "Access-Control-Allow-Origin": "*"
     },
-    disableHostCheck: true
+    disableHostCheck: true,
+    watchContentBase: true
   });
 
 server.listen(env.PORT);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,8 @@ var options = {
   },
   output: {
     path: path.join(__dirname, "build"),
-    filename: "[name].bundle.js"
+    filename: "[name].bundle.js",
+    publicPath: "build/"
   },
   module: {
     rules: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,8 @@ var options = {
   entry: {
     popup: path.join(__dirname, "src", "js", "popup.js"),
     options: path.join(__dirname, "src", "js", "options.js"),
-    background: path.join(__dirname, "src", "js", "background.js")
+    background: path.join(__dirname, "src", "js", "background.js"),
+    hot_reload: path.join(__dirname, "src", "js", "hot-reload.js")
   },
   output: {
     path: path.join(__dirname, "build"),


### PR DESCRIPTION
As from the title: this supports automatically reloading the extension from the `build/` folder, when it see changes.

Activating a "build-when-save" functionality on their IDE, the users can just code and have the extension be automatically Built & Reloaded in Chrome, when they save some change.

Sorry if I didn't open an issue beforehand; I didn't have much to discuss, since I added the feature mainly for my own necessity.
If you think it might be worth to merge, you're welcome 🙂
Otherwise the PR can be closed and at least will be available to others that might want to use it.